### PR TITLE
restrict transformers version to less than 4.13.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     },
     install_requires=[
         "spacy-transformers>=1.1.2,<1.2.0",
+        "transformers<4.13.0",
     ],
     license="MIT",
     name="ginza-transformers",

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setup(
     name="ginza-transformers",
     packages=find_packages(include=["ginza_transformers", "ginza_transformers.layers"]),
     url="https://github.com/megagonlabs/ginza-transformers",
-    version='0.4.0',
+    version='0.4.1',
 )


### PR DESCRIPTION
As reported in https://github.com/megagonlabs/ginza/issues/234, transformers >= 4.13.0 occurs FileNotFoundError.
